### PR TITLE
fix invalid findMany crashing the bot

### DIFF
--- a/lib/classes/Server.ts
+++ b/lib/classes/Server.ts
@@ -125,7 +125,7 @@ export default class Server {
 		});
 
 		setInterval(async () => {
-			const jobs = await this.prisma.job.findMany({});
+			const jobs = await this.prisma.job.findMany();
 
 			return Promise.all(
 				jobs


### PR DESCRIPTION
to get all of a type, you call it with no params

calling it with {} leads to an error subsequently crashing the bot

docs: https://www.prisma.io/docs/orm/prisma-client/queries/crud#get-all-records